### PR TITLE
feat: Updated the manifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -34,3 +34,5 @@ files {
 }
 
 ui_page 'web/build/index.html'
+
+provide 'qb-clothing'


### PR DESCRIPTION
This was added by CFX.re to help with the "dependences" in the manifest. This will make it so manifests with `qb-clothing` will still work. Never added this to my fork of it but I do remember using it for my older version of `aj-inventory`